### PR TITLE
Prevent potential vuln, not yet exploitable

### DIFF
--- a/src/main/resources/io/jenkins/plugins/jenkinswork/statusparameter/SprintsParameter/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/jenkinswork/statusparameter/SprintsParameter/index.jelly
@@ -1,6 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-  <f:entry title="${it.name}" description="${it.description}">
+  <j:set var="escapeEntryTitleAndDescription" value="false"/>
+  <f:entry title="${h.escape(it.name)}" description="${it.formattedDescription}">
     <!-- this div is required because of ParametersDefinitionProperty.java#117 -->
     <div name="parameter">
       <input type="hidden" name="name" value="${it.name}"/>

--- a/src/main/resources/io/jenkins/plugins/jenkinswork/statusparameter/StatusParamValue/value.jelly
+++ b/src/main/resources/io/jenkins/plugins/jenkinswork/statusparameter/StatusParamValue/value.jelly
@@ -1,6 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:entry title="${it.name}">
+    <j:set var="escapeEntryTitleAndDescription" value="false"/>
+    <f:entry title="${h.escape(it.name)}">
         <f:textbox name="${it.name}" value="${it.value}" />
     </f:entry>
 </j:jelly>


### PR DESCRIPTION
The Sprints parameter is not functional yet; the `@Extension` annotation is commented out in [SprintsParameter.java#L121](https://github.com/Kevin-CB/zohosprints-plugin/blob/b86f719a0d03cb8ed5b2a40f546ebc640f69a22b/src/main/java/io/jenkins/plugins/jenkinswork/statusparameter/SprintsParameter.java#L121).

However, enabling this parameter would cause an XSS.

When provided to the `f:entry` field, title and description need to be escaped if they contain untrusted data, seehttps://www.jenkins.io/security/advisory/2022-06-22/#SECURITY-2781 